### PR TITLE
Add jsonlite to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Suggests:
     BiocStyle,
     DelayedArray,
     HDF5Array,
+    jsonlite,
     knitr,
     processx,
     rhdf5 (>= 2.52.1),


### PR DESCRIPTION
**Related to:** #455

`write_zarr_string_array()` and `write_zarr_string_scalar()` patch the array metadata with `jsonlite::read_json()`/`write_json()`, but jsonlite is not declared anywhere in `DESCRIPTION`. `R CMD check` reports this under "checking dependencies in R code":

```
'::' or ':::' import not declared from: 'jsonlite'
```

It is only a NOTE, which is why CI has stayed green, but Bioconductor expects a clean check.

