### PR TITLE
Use the format of an existing Zarr store when writing to it

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -313,7 +313,7 @@ AbstractAnnData <- R6::R6Class(
         "lz4"
       ),
       mode = c("w-", "r", "r+", "a", "w", "x"),
-      zarr_format = getOption("anndataR.zarr_format", 3L)
+      zarr_format = NULL
     ) {
       as_ZarrAnnData(
         adata = self,

--- a/R/Rarr_utils.R
+++ b/R/Rarr_utils.R
@@ -17,6 +17,8 @@ create_zarr_group <- function(
   name,
   format
 ) {
+  format <- check_zarr_format(format)
+
   # Split "a/b/c" into c("a", "b", "c")
   split_name <- strsplit(name, split = "/", fixed = TRUE)[[1]]
   if (length(split_name) > 1) {
@@ -35,23 +37,78 @@ create_zarr_group <- function(
     }
   }
   dir.create(file.path(store, split_name[1]), showWarnings = FALSE)
-  format <- paste0("v", format)
-  switch(
-    format,
-    v2 = {
-      write(
-        "{\"zarr_format\":2}",
-        file = file.path(store, split_name[1], ".zgroup")
-      )
-    },
-    v3 = {
-      write(
-        "{\"zarr_format\": 3,\n\"node_type\": \"group\"}",
-        file = file.path(store, split_name[1], "zarr.json")
-      )
-    },
-    cli_abort("Incorrect Zarr format specified. Must be '2' or '3'.")
-  )
+  if (format == 2L) {
+    write(
+      "{\"zarr_format\":2}",
+      file = file.path(store, split_name[1], ".zgroup")
+    )
+  } else {
+    write(
+      "{\"zarr_format\": 3,\n\"node_type\": \"group\"}",
+      file = file.path(store, split_name[1], "zarr.json")
+    )
+  }
+}
+
+#' check_zarr_format
+#'
+#' Check that a Zarr format is one of the supported versions
+#'
+#' @param format Zarr format
+#'
+#' @return `format` as an integer
+#'
+#' @noRd
+check_zarr_format <- function(format, call = rlang::caller_env()) {
+  if (
+    length(format) != 1L ||
+      !is.numeric(format) ||
+      is.na(format) ||
+      !format %in% c(2L, 3L)
+  ) {
+    cli_abort(
+      "{.arg zarr_format} must be either {.val {2L}} or {.val {3L}}, \\
+      not {.val {format}}.",
+      call = call
+    )
+  }
+
+  as.integer(format)
+}
+
+#' get_zarr_format
+#'
+#' Determine the Zarr format of an existing store from its root metadata
+#'
+#' @param store The location of the Zarr store
+#'
+#' @return The Zarr format of `store` as an integer
+#'
+#' @noRd
+get_zarr_format <- function(store, call = rlang::caller_env()) {
+  files <- list.files(store, all.files = TRUE, recursive = FALSE)
+
+  is_v2 <- any(c(".zgroup", ".zarray") %in% files)
+  is_v3 <- "zarr.json" %in% files
+
+  if (is_v2 && is_v3) {
+    cli_abort(
+      c(
+        "Store {.file {store}} contains both Zarr v2 and v3 root metadata.",
+        "i" = "Found both {.file .zgroup}/{.file .zarray} and {.file zarr.json}."
+      ),
+      call = call
+    )
+  }
+
+  if (!is_v2 && !is_v3) {
+    cli_abort(
+      "Could not determine the Zarr format of {.file {store}}.",
+      call = call
+    )
+  }
+
+  if (is_v2) 2L else 3L
 }
 
 #' create_zarr

--- a/R/ZarrAnnData.R
+++ b/R/ZarrAnnData.R
@@ -342,7 +342,7 @@ ZarrAnnData <- R6::R6Class(
         "zlib",
         "lz4"
       ),
-      zarr_format = getOption("anndataR.zarr_format", 3L)
+      zarr_format = NULL
     ) {
       check_requires("ZarrAnnData", "Rarr", where = "Bioc")
 
@@ -351,7 +351,10 @@ ZarrAnnData <- R6::R6Class(
 
       private$.compression <- compression
 
-      private$.zarrformat <- zarr_format
+      if (!is.null(zarr_format)) {
+        zarr_format <- check_zarr_format(zarr_format)
+      }
+
       is_readonly <- FALSE
 
       if (is.character(file)) {
@@ -385,10 +388,35 @@ ZarrAnnData <- R6::R6Class(
           )
         }
 
+        # Truncate any existing store so that "w" cannot leave metadata of the
+        # previous store behind, which would result in a mixed format store
+        if (mode == "w" && dir.exists(file)) {
+          unlink(file, recursive = TRUE)
+        }
+
         if (mode %in% c("w", "w-", "x")) {
+          private$.zarrformat <- check_zarr_format(
+            zarr_format %||% getOption("anndataR.zarr_format", 3L)
+          )
           create_zarr(file, format = private$.zarrformat)
-        } else if (mode == "r") {
-          is_readonly <- TRUE
+        } else {
+          # An existing store dictates its own format, otherwise appending to it
+          # would produce a store with a mix of v2 and v3 nodes
+          private$.zarrformat <- get_zarr_format(file)
+          if (!is.null(zarr_format) && zarr_format != private$.zarrformat) {
+            cli_abort(
+              c(
+                "Store {.file {file}} is in Zarr v{private$.zarrformat} format
+                 but {.arg zarr_format} is set to {.val {zarr_format}}.",
+                "i" = "Use {.code mode = \"w\"} to rewrite the store in Zarr
+                       v{zarr_format} format."
+              ),
+              call = rlang::caller_env()
+            )
+          }
+          if (mode == "r") {
+            is_readonly <- TRUE
+          }
         }
       } else {
         cli_abort(
@@ -531,11 +559,14 @@ ZarrAnnData <- R6::R6Class(
 #'   * `r+` opens an existing file for read/write
 #'   * `w` creates a file, truncating any existing ones
 #'   * `w-`/`x` are synonyms, creating a file and failing if it already exists
-#' @param zarr_format The format to use when writing the Zarr file.
-#'   Should be either 2 or 3 for Zarr v2 or v3 formats, respectively.
-#'   Unless it is specified, Zarr v3 will be used by default.
-#'   The format can also be specified using
-#'   `anndataR.zarr_format`, e.g. `options(anndataR.zarr_format = 2)`.
+#' @param zarr_format The format to use when creating the Zarr store. Should be
+#'   either 2 or 3 for Zarr v2 or v3 formats, respectively. The default can also
+#'   be set using the `anndataR.zarr_format` option, e.g.
+#'   `options(anndataR.zarr_format = 2)`. If neither is set, Zarr v3 is used.
+#'
+#'   When an existing store is opened, that store's format is used instead and
+#'   setting `zarr_format` to a different format is an error. Use
+#'   `mode = "w"` to rewrite an existing store in another format.
 #'
 #' @return A [`ZarrAnnData`] object with the same data as the input `AnnData`
 #'   object.
@@ -559,7 +590,7 @@ as_ZarrAnnData <- function(
     "lz4"
   ),
   mode = c("w-", "r", "r+", "a", "w", "x"),
-  zarr_format = getOption("anndataR.zarr_format", 3L)
+  zarr_format = NULL
 ) {
   if (!(inherits(adata, "AbstractAnnData"))) {
     cli_abort(

--- a/man/AbstractAnnData.Rd
+++ b/man/AbstractAnnData.Rd
@@ -387,7 +387,7 @@ See \code{\link[=as_ZarrAnnData]{as_ZarrAnnData()}} for more details on the conv
   file,
   compression = c("none", "gzip", "blosc", "zstd", "lzma", "bz2", "zlib", "lz4"),
   mode = c("w-", "r", "r+", "a", "w", "x"),
-  zarr_format = getOption("anndataR.zarr_format", 3L)
+  zarr_format = NULL
 )}
     \if{html}{\out{</div>}}
   }

--- a/man/ZarrAnnData.Rd
+++ b/man/ZarrAnnData.Rd
@@ -107,7 +107,7 @@ Other AnnData classes:
   shape = NULL,
   mode = c("a", "r", "r+", "w", "w-", "x"),
   compression = c("none", "gzip", "blosc", "zstd", "lzma", "bz2", "zlib", "lz4"),
-  zarr_format = getOption("anndataR.zarr_format", 3L)
+  zarr_format = NULL
 )}
     \if{html}{\out{</div>}}
   }

--- a/man/as_ZarrAnnData.Rd
+++ b/man/as_ZarrAnnData.Rd
@@ -9,7 +9,7 @@ as_ZarrAnnData(
   file,
   compression = c("none", "gzip", "blosc", "zstd", "lzma", "bz2", "zlib", "lz4"),
   mode = c("w-", "r", "r+", "a", "w", "x"),
-  zarr_format = getOption("anndataR.zarr_format", 3L)
+  zarr_format = NULL
 )
 }
 \arguments{
@@ -30,11 +30,14 @@ Zarr file. Can be one of \code{"none"}, \code{"gzip"}, \code{"blosc"}, \code{"zs
 \item \verb{w-}/\code{x} are synonyms, creating a file and failing if it already exists
 }}
 
-\item{zarr_format}{The format to use when writing the Zarr file.
-Should be either 2 or 3 for Zarr v2 or v3 formats, respectively.
-Unless it is specified, Zarr v3 will be used by default.
-The format can also be specified using
-\code{anndataR.zarr_format}, e.g. \code{options(anndataR.zarr_format = 2)}.}
+\item{zarr_format}{The format to use when creating the Zarr store. Should be
+either 2 or 3 for Zarr v2 or v3 formats, respectively. The default can also
+be set using the \code{anndataR.zarr_format} option, e.g.
+\code{options(anndataR.zarr_format = 2)}. If neither is set, Zarr v3 is used.
+
+When an existing store is opened, that store's format is used instead and
+setting \code{zarr_format} to a different format is an error. Use
+\code{mode = "w"} to rewrite an existing store in another format.}
 }
 \value{
 A \code{\link{ZarrAnnData}} object with the same data as the input \code{AnnData}

--- a/tests/testthat/helper-zarr.R
+++ b/tests/testthat/helper-zarr.R
@@ -1,13 +1,54 @@
+#' Determine the Zarr format of a single node in a store
+#'
+#' Fails if the node carries both v2 and v3 metadata, as such a node is not a
+#' valid Zarr node and would otherwise silently be reported as v3.
 zarr_node_format <- function(store, name) {
   files <- list.files(
     file.path(store, name),
     all.files = TRUE
   )
-  if ("zarr.json" %in% files) {
-    3L
-  } else if (any(c(".zgroup", ".zarray") %in% files)) {
-    2L
-  } else {
+
+  is_v2 <- any(c(".zgroup", ".zarray") %in% files)
+  is_v3 <- "zarr.json" %in% files
+
+  if (is_v2 && is_v3) {
+    stop("node '", name, "' contains both v2 and v3 metadata!")
+  }
+  if (!is_v2 && !is_v3) {
     stop("zarr format cannot be determined!")
   }
+
+  if (is_v2) 2L else 3L
+}
+
+#' Determine the Zarr format of every node in a store
+#'
+#' Walks the whole store rather than just the top level, so that a v3 array
+#' nested inside a v2 group is detected.
+zarr_store_formats <- function(store) {
+  dirs <- list.dirs(store, recursive = TRUE, full.names = TRUE)
+  nodes <- dirs[
+    vapply(
+      dirs,
+      function(dir) {
+        files <- list.files(dir, all.files = TRUE)
+        any(ZARR_METADATA_FILES %in% files)
+      },
+      logical(1)
+    )
+  ]
+
+  vapply(
+    nodes,
+    function(node) zarr_node_format(node, ""),
+    integer(1),
+    USE.NAMES = FALSE
+  )
+}
+
+#' Expect every node in a store to be written in `format`
+expect_zarr_store_format <- function(store, format) {
+  formats <- zarr_store_formats(store)
+  testthat::expect_gt(length(formats), 0L)
+  testthat::expect_equal(unique(formats), as.integer(format))
 }

--- a/tests/testthat/test-Zarr-write.R
+++ b/tests/testthat/test-Zarr-write.R
@@ -351,7 +351,7 @@ for (zarr_format in c(2, 3)) {
         sce <- generate_dataset(format = "SingleCellExperiment")
         write_zarr(sce, store)
         expect_true(dir.exists(store))
-        expect_equal(zarr_node_format(store, ""), zarr_format)
+        expect_zarr_store_format(store, zarr_format)
       })
 
       test_that("writing Zarr from SingleCellExperiment works for manual zarr format", {
@@ -361,7 +361,7 @@ for (zarr_format in c(2, 3)) {
         zarr_format_manual <- setdiff(c(2, 3), zarr_format)
         write_zarr(sce, store, zarr_format = zarr_format_manual)
         expect_true(dir.exists(store))
-        expect_equal(zarr_node_format(store, ""), zarr_format_manual)
+        expect_zarr_store_format(store, zarr_format_manual)
         expect_equal(getOption("anndataR.zarr_format"), zarr_format)
       })
 
@@ -371,7 +371,7 @@ for (zarr_format in c(2, 3)) {
         seurat <- generate_dataset(format = "Seurat")
         write_zarr(seurat, store)
         expect_true(dir.exists(store))
-        expect_equal(zarr_node_format(store, ""), zarr_format)
+        expect_zarr_store_format(store, zarr_format)
       })
 
       test_that("writing Zarr from Seurat works for manual zarr format", {
@@ -381,8 +381,81 @@ for (zarr_format in c(2, 3)) {
         zarr_format_manual <- setdiff(c(2, 3), zarr_format)
         write_zarr(seurat, store, zarr_format = zarr_format_manual)
         expect_true(dir.exists(store))
-        expect_equal(zarr_node_format(store, ""), zarr_format_manual)
+        expect_zarr_store_format(store, zarr_format_manual)
         expect_equal(getOption("anndataR.zarr_format"), zarr_format)
+      })
+
+      # a small AnnData covering the element types that are written as nested
+      # groups, as those are where a mixed format store would show up first
+      make_adata <- function() {
+        AnnData(
+          X = matrix(as.double(1:6), nrow = 2, ncol = 3),
+          obs = data.frame(
+            row.names = c("c1", "c2"),
+            categorical = factor(c("a", "b")),
+            string = c("x", "y")
+          ),
+          var = data.frame(row.names = c("g1", "g2", "g3")),
+          layers = list(double = matrix(as.double(7:12), nrow = 2, ncol = 3)),
+          uns = list(scalar = "a string", nested = list(number = 1))
+        )
+      }
+
+      test_that("the zarr_format argument overrides the option everywhere", {
+        store <- tempfile(fileext = ".zarr")
+        zarr_format_manual <- setdiff(c(2, 3), zarr_format)
+        write_zarr(make_adata(), store, zarr_format = zarr_format_manual)
+        expect_zarr_store_format(store, zarr_format_manual)
+        expect_equal(getOption("anndataR.zarr_format"), zarr_format)
+      })
+
+      test_that("writing to an existing store keeps the format of that store", {
+        store <- tempfile(fileext = ".zarr")
+        zarr_format_manual <- setdiff(c(2, 3), zarr_format)
+        write_zarr(make_adata(), store, zarr_format = zarr_format_manual)
+
+        # the option says one thing, the store on disk says another
+        adata <- suppressWarnings(ZarrAnnData$new(store, mode = "r+"))
+        adata$obsm <- list(pca = matrix(as.double(1:4), nrow = 2, ncol = 2))
+
+        expect_zarr_store_format(store, zarr_format_manual)
+      })
+
+      test_that("asking for a different format than an existing store errors", {
+        store <- tempfile(fileext = ".zarr")
+        zarr_format_manual <- setdiff(c(2, 3), zarr_format)
+        write_zarr(make_adata(), store, zarr_format = zarr_format_manual)
+
+        expect_error(
+          suppressWarnings(
+            ZarrAnnData$new(store, mode = "r+", zarr_format = zarr_format)
+          ),
+          "is in Zarr v"
+        )
+      })
+
+      test_that("mode 'w' rewrites an existing store in the other format", {
+        store <- tempfile(fileext = ".zarr")
+        zarr_format_manual <- setdiff(c(2, 3), zarr_format)
+        write_zarr(make_adata(), store, zarr_format = zarr_format_manual)
+
+        write_zarr(make_adata(), store, mode = "w", zarr_format = zarr_format)
+
+        expect_zarr_store_format(store, zarr_format)
+        expect_no_error(read_zarr(store))
+      })
+
+      test_that("an invalid zarr_format errors", {
+        for (invalid in list(1, 4, "3", NA, c(2, 3))) {
+          expect_error(
+            write_zarr(
+              make_adata(),
+              tempfile(fileext = ".zarr"),
+              zarr_format = invalid
+            ),
+            "must be either"
+          )
+        }
       })
 
       dir_size <- function(path) {

--- a/tests/testthat/test-ZarrAnnData.R
+++ b/tests/testthat/test-ZarrAnnData.R
@@ -141,6 +141,9 @@ test_that("writing X works", {
 
   X <- matrix(rnorm(10 * 20), nrow = 10, ncol = 20)
   expect_silent(zarr$X <- X)
+  # the store was created as v2, so everything written into it must be v2 too,
+  # whatever the anndataR.zarr_format option happens to be
+  expect_zarr_store_format(store, 2)
   unlink(store, recursive = TRUE)
 })
 


### PR DESCRIPTION
**Related to:** #455, https://github.com/scverse/anndataR/pull/455#discussion_r3460021722

Opening an existing store took the format from `getOption("anndataR.zarr_format", 3L)` rather than from the store itself, so writing into a Zarr v2 store while the option was 3 produced v3 nodes inside it. Python `anndata` reads such a store without an error, but with the affected slot silently missing:

```r
options(anndataR.zarr_format = 2)
write_zarr(adata, store)

options(anndataR.zarr_format = 3)
z <- ZarrAnnData$new(store, mode = "r+")
z$layers <- list(counts = counts)
```

```python
>>> anndata.read_zarr(store).layers.keys()
ZarrUserWarning: Object at layers is not recognized as a component of a Zarr hierarchy.
KeysView(Layers with keys: )
```

* Add `get_zarr_format()` and use it in `ZarrAnnData$new()`, so an existing store dictates its own format.
* Error when `zarr_format` asks for a different format than the store on disk, instead of quietly writing the other one.
* Truncate the store for `mode = "w"`, as documented and as `HDF5AnnData` already does. Rewriting a v2 store as v3 used to leave both `.zgroup` and `zarr.json` at the root, after which the store could not be read back at all.
* Add `check_zarr_format()`. `zarr_format` was not validated anywhere, so a typo could delete an element and downgrade the failure to a warning.
* Make `zarr_node_format()` fail on nodes carrying both v2 and v3 metadata, and add `expect_zarr_store_format()`, which walks the whole store rather than just the root. The existing override tests only asserted on the root, so a v3 array nested in a v2 group would have gone unnoticed.

The entrypoints now default to `zarr_format = NULL` and the option is read in one place, when the store is created.
