### PR TITLE
Stop ignoring all Python warnings in the roundtrip tests

### DIFF
--- a/tests/testthat/helper-skip_if_no_zarr.R
+++ b/tests/testthat/helper-skip_if_no_zarr.R
@@ -14,4 +14,16 @@ skip_if_no_zarr <- function() {
     "ignore",
     message = "Writing zarr v2 data will no longer be the default"
   )
+
+  # Warnings emitted by Python zarr when it writes the v3 stores used by the
+  # roundtrip tests. Filter these by message rather than ignoring everything,
+  # so that warnings we do care about still show up.
+  wn$filterwarnings(
+    "ignore",
+    message = "zarr v3 autosharding will be the default"
+  )
+  wn$filterwarnings(
+    "ignore",
+    message = "Consolidated metadata is currently not part in the Zarr format 3"
+  )
 }

--- a/tests/testthat/test-Zarr-write.R
+++ b/tests/testthat/test-Zarr-write.R
@@ -410,8 +410,15 @@ for (zarr_format in c(2, 3)) {
           zarr_format = zarr_format
         )
 
-        # TODO: blosc does not work for now
-        comp_list <- c("gzip", "zstd", "lzma", "bz2", "zlib", "lz4")
+        comp_list <- c(
+          "gzip",
+          "blosc",
+          "zstd",
+          "lzma",
+          "bz2",
+          "zlib",
+          "lz4"
+        )
         for (comp in comp_list) {
           write_zarr(
             adata,
@@ -419,8 +426,10 @@ for (zarr_format in c(2, 3)) {
             compression = comp,
             zarr_format = zarr_format
           )
+          # measure before removing the store, otherwise the comparison is
+          # always against a size of zero
+          expect_gt(dir_size(store_none), dir_size(store_compressed))
           unlink(store_compressed, recursive = TRUE)
-          expect_true(dir_size(store_none) > dir_size(store_compressed))
         }
       })
     }

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -7,10 +7,6 @@ ad <- reticulate::import("anndata", convert = FALSE)
 da <- reticulate::import("dummy_anndata", convert = FALSE)
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 test_names <- names(da$matrix_generators)

--- a/tests/testthat/test-roundtrip-empty.R
+++ b/tests/testthat/test-roundtrip-empty.R
@@ -10,10 +10,6 @@ tryCatch(ad$settings$allow_write_nullable_strings <- TRUE, error = function(e) {
 })
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 name <- "empty"

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -7,10 +7,6 @@ ad <- reticulate::import("anndata", convert = FALSE)
 da <- reticulate::import("dummy_anndata", convert = FALSE)
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 test_names <- names(da$matrix_generators)

--- a/tests/testthat/test-roundtrip-obsmvarm.R
+++ b/tests/testthat/test-roundtrip-obsmvarm.R
@@ -7,10 +7,6 @@ ad <- reticulate::import("anndata", convert = FALSE)
 da <- reticulate::import("dummy_anndata", convert = FALSE)
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 test_names <- c(

--- a/tests/testthat/test-roundtrip-obspvarp.R
+++ b/tests/testthat/test-roundtrip-obspvarp.R
@@ -7,10 +7,6 @@ ad <- reticulate::import("anndata", convert = FALSE)
 da <- reticulate::import("dummy_anndata", convert = FALSE)
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 test_names <- names(da$matrix_generators)

--- a/tests/testthat/test-roundtrip-obsvar.R
+++ b/tests/testthat/test-roundtrip-obsvar.R
@@ -7,10 +7,6 @@ ad <- reticulate::import("anndata", convert = FALSE)
 da <- reticulate::import("dummy_anndata", convert = FALSE)
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 test_names <- names(da$vector_generators)

--- a/tests/testthat/test-roundtrip-uns-nested.R
+++ b/tests/testthat/test-roundtrip-uns-nested.R
@@ -7,10 +7,6 @@ ad <- reticulate::import("anndata", convert = FALSE)
 da <- reticulate::import("dummy_anndata", convert = FALSE)
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 test_names <- c(

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -7,10 +7,6 @@ ad <- reticulate::import("anndata", convert = FALSE)
 da <- reticulate::import("dummy_anndata", convert = FALSE)
 bi <- reticulate::import_builtins()
 
-# suppress ZarrUserWarnings
-wr <- reticulate::import("warnings")
-wr$filterwarnings("ignore")
-
 known_issues <- read_known_issues()
 
 test_names <- c(


### PR DESCRIPTION
**Related to:** #455

Eight roundtrip test files gained a blanket `warnings.filterwarnings("ignore")` at the top level, which is never restored and so applies to the rest of the session. The only warnings those tests actually emit are two, both from Python zarr:

```
UserWarning: zarr v3 autosharding will be the default in the next minor release.
ZarrUserWarning: Consolidated metadata is currently not part in the Zarr format 3 specification.
```

* Filter those two by message in `skip_if_no_zarr()`, next to the `anndata` one that was already there, and drop the blanket filters. The roundtrip output stays just as quiet, but warnings we do care about are no longer swallowed.
* Put `blosc` back in the compression test. The `# TODO: blosc does not work for now` looks stale -- it writes and reads back fine here with Rarr 2.1.18 for both v2 and v3, and it is still an accepted value of `compression`.
* Compare the store sizes before removing the compressed store. The `unlink()` ran first, so the size compared against was always zero and the expectation could never fail. That one is not new, it is on `devel` too.
