### PR TITLE
Document the Zarr format without leaking the option

### DIFF
--- a/R/write_zarr.R
+++ b/R/write_zarr.R
@@ -21,6 +21,13 @@
 #'
 #' @details
 #'
+#' ## Zarr format
+#'
+#' New stores are written in the Zarr v3 format. Pass `zarr_format = 2` to write
+#' a Zarr v2 store instead, or set `options(anndataR.zarr_format = 2)` to change
+#' the default for the current session. Writing to an existing store always uses
+#' the format of that store. See [as_ZarrAnnData()] for details.
+#'
 #' ## `NULL` values
 #'
 #' For compatibility with changes in Python **anndata** 0.12.0, `NULL` values
@@ -45,14 +52,9 @@
 #' zarr_store <- tempfile(fileext = ".zarr")
 #' adata$write_zarr(zarr_store)
 #'
-#' # set Zarr version to 2.
-#' options(anndataR.zarr_format = 2)
+#' # Write a Zarr v2 store instead of the default v3
 #' zarr_store <- tempfile(fileext = ".zarr")
-#' adata$write_zarr(zarr_store)
-#'
-#' # write .zarr as version 3
-#' zarr_store <- tempfile(fileext = ".zarr")
-#' adata$write_zarr(zarr_store, zarr_format = 3)
+#' adata$write_zarr(zarr_store, zarr_format = 2)
 #'
 #' # Write a SingleCellExperiment as a Zarr store
 #' if (requireNamespace("SingleCellExperiment", quietly = TRUE)) {

--- a/R/write_zarr_helpers.R
+++ b/R/write_zarr_helpers.R
@@ -8,11 +8,9 @@
 #' @param compression The compression to use when writing the element.
 #'   One of `"none"`, `"gzip"`, `"blosc"`, `"zstd"`, `"lzma"`, `"bz2"`,
 #'   `"zlib"`, `"lz4"`.
-#' @param zarr_format The format to use when writing the Zarr file.
-#'   Should be either 2 or 3 for Zarr v2 or v3 formats, respectively.
-#'   Unless it is specified, Zarr v3 will be used by default.
-#'   The format can also be specified using
-#'   `anndataR.zarr_format`, e.g. `options(anndataR.zarr_format = 2)`.
+#' @param zarr_format The format to write the element in, either 2 or 3 for the
+#'   Zarr v2 or v3 formats. Always passed explicitly by the caller so that all
+#'   elements of a store end up in the same format.
 #' @param stop_on_error Whether to stop on error or generate a warning instead
 #' @param ... Additional arguments passed to writing functions
 #'

--- a/man/write_zarr.Rd
+++ b/man/write_zarr.Rd
@@ -41,6 +41,14 @@ See \code{help("compressors", package = "Rarr")}.}
 Write a Zarr file
 }
 \details{
+\subsection{Zarr format}{
+
+New stores are written in the Zarr v3 format. Pass \code{zarr_format = 2} to write
+a Zarr v2 store instead, or set \code{options(anndataR.zarr_format = 2)} to change
+the default for the current session. Writing to an existing store always uses
+the format of that store. See \code{\link[=as_ZarrAnnData]{as_ZarrAnnData()}} for details.
+}
+
 \subsection{\code{NULL} values}{
 
 For compatibility with changes in Python \strong{anndata} 0.12.0, \code{NULL} values
@@ -63,14 +71,9 @@ adata <- AnnData(
 zarr_store <- tempfile(fileext = ".zarr")
 adata$write_zarr(zarr_store)
 
-# set Zarr version to 2.
-options(anndataR.zarr_format = 2)
+# Write a Zarr v2 store instead of the default v3
 zarr_store <- tempfile(fileext = ".zarr")
-adata$write_zarr(zarr_store)
-
-# write .zarr as version 3
-zarr_store <- tempfile(fileext = ".zarr")
-adata$write_zarr(zarr_store, zarr_format = 3)
+adata$write_zarr(zarr_store, zarr_format = 2)
 
 # Write a SingleCellExperiment as a Zarr store
 if (requireNamespace("SingleCellExperiment", quietly = TRUE)) {

--- a/vignettes/anndataR.Rmd
+++ b/vignettes/anndataR.Rmd
@@ -223,24 +223,18 @@ tmpfile <- tempfile(fileext = ".zarr")
 write_zarr(obj, tmpfile)
 ```
 
-We support reading and writing Zarr v2 and v3 where Zarr v3 is the default. 
-
-To use Zarr v2, globally set `options(anndataR.zarr_format = 2)` or use `zarr_format = 2` to set it in an individual function all. 
+Both Zarr v2 and v3 can be read and written, and new stores are written as Zarr v3 by default.
+To write a Zarr v2 store, pass `zarr_format = 2`:
 
 ```{r write-zarr-format}
-options(anndataR.zarr_format = 2)
-
-tmpfile <- tempfile(fileext = ".zarr")
-adata$write_zarr(tmpfile)
-
 tmpfile <- tempfile(fileext = ".zarr")
 adata$write_zarr(tmpfile, zarr_format = 2)
 ```
 
-See more about Zarr data formats below:
+Setting `options(anndataR.zarr_format = 2)` changes the default for the rest of the session.
+Writing to a store that already exists always uses the format of that store, so appending to a Zarr v2 store never produces a mix of the two.
 
-* https://zarr.readthedocs.io/en/stable/
-* https://zarr-specs.readthedocs.io/en/latest/specs.html
+See the [Zarr documentation](https://zarr.readthedocs.io/en/stable/) and the [Zarr specifications](https://zarr-specs.readthedocs.io/en/latest/specs.html) for more about the two formats.
 
 ## Subsetting `AnnData` objects {#subsetting}
 


### PR DESCRIPTION
**Related to:** #455

* Drop `options(anndataR.zarr_format = 2)` from the `write_zarr()` example and from the vignette. Neither restored it, so the example leaked the option into every example running after it in the same `R CMD check` session, and the vignette silently wrote every later store as v2.
* Describe the Zarr format under `@details` in `write_zarr()`. It only arrives through `...`, so there was nowhere on that page saying what `zarr_format` does or that v3 is the default.
* The two vignette examples both wrote v2, so they did not show the difference they were meant to show. Keep the explicit argument and explain the option in prose instead.
* Fix "individual function all" and turn the two bare URLs into links.
