### PR TITLE
Extract the vlen-utf8 metadata patch into a helper

### DIFF
--- a/R/write_zarr_helpers.R
+++ b/R/write_zarr_helpers.R
@@ -363,6 +363,58 @@ write_zarr_nullable_integer <- function(
   write_zarr_encoding(store, name, "nullable-integer", version, zarr_format)
 }
 
+#' Patch Zarr array metadata to declare VLen-UTF8 strings
+#'
+#' TEMPORARY WORKAROUND. Rarr has no interface for writing VLen-UTF8 strings, so
+#' the array is written with a placeholder data type and its metadata is then
+#' rewritten by hand: a `vlen-utf8` filter for Zarr v2, and the `bytes` codec
+#' swapped for `vlen-utf8` plus a `string` data type for Zarr v3.
+#'
+#' Editing metadata behind Rarr's back like this is fragile, and it means the
+#' array on disk briefly disagrees with what Rarr thinks it wrote.
+#'
+#' TODO: Remove this function and pass the string type to Rarr directly once
+#' https://github.com/Huber-group-EMBL/Rarr/issues/111 is resolved.
+#'
+#' @param store The location of the Zarr store
+#' @param name Name of the array within the store
+#' @param zarr_format The format the array was written in
+#'
+#' @noRd
+patch_zarr_vlen_utf8 <- function(store, name, zarr_format) {
+  metadata_path <- file.path(
+    store,
+    name,
+    if (zarr_format == 2L) ".zarray" else "zarr.json"
+  )
+  metadata <- jsonlite::read_json(metadata_path)
+
+  if (zarr_format == 2L) {
+    metadata$filters <- c(metadata$filters, list(list(id = "vlen-utf8")))
+  } else {
+    metadata$data_type <- "string"
+    # There should be only one array-bytes codec
+    metadata$codecs <- lapply(
+      metadata$codecs,
+      function(codec) {
+        if (codec$name == "bytes") {
+          list(name = "vlen-utf8")
+        } else {
+          codec
+        }
+      }
+    )
+  }
+
+  jsonlite::write_json(
+    metadata,
+    metadata_path,
+    auto_unbox = TRUE,
+    pretty = TRUE,
+    null = "null"
+  )
+}
+
 #' Write Zarr string array
 #'
 #' Write a string array to a Zarr store
@@ -396,52 +448,15 @@ write_zarr_string_array <- function(
       dim = dims,
       chunk_dim = chunk_dims,
       order = if (length(dims) > 0) "C" else "F",
+      # placeholder type, rewritten to a string type just below
       data_type = "|O",
       compressor = .get_compressor(compression),
       zarr_version = zarr_format
     )
   })
-  # Rarr doesn't yet provide an explicit interface to deal with VLen-UTF8 so
-  # we patch the metadata by hand.
-  # Will be resolved by https://github.com/Huber-group-EMBL/Rarr/issues/111.
-  if (zarr_format == 2L) {
-    zarr_json_path <- file.path(store, name, ".zarray")
-    zarr_json <- jsonlite::read_json(zarr_json_path)
-    zarr_json$filters <- c(
-      zarr_json$filters,
-      list(list(id = "vlen-utf8"))
-    )
-    jsonlite::write_json(
-      zarr_json,
-      zarr_json_path,
-      auto_unbox = TRUE,
-      pretty = TRUE,
-      null = "null"
-    )
-  }
-  if (zarr_format == 3L) {
-    zarr_json_path <- file.path(store, name, "zarr.json")
-    zarr_json <- jsonlite::read_json(zarr_json_path)
-    zarr_json$data_type <- "string"
-    # There should be only one bytes-array codec
-    zarr_json$codecs <- lapply(
-      zarr_json$codecs,
-      function(codec) {
-        if (codec$name == "bytes") {
-          list(name = "vlen-utf8")
-        } else {
-          codec
-        }
-      }
-    )
-    jsonlite::write_json(
-      zarr_json,
-      zarr_json_path,
-      auto_unbox = TRUE,
-      pretty = TRUE,
-      null = "null"
-    )
-  }
+  # TODO: Remove this call, and write the array as strings directly, once
+  # https://github.com/Huber-group-EMBL/Rarr/issues/111 is resolved
+  patch_zarr_vlen_utf8(store, name, zarr_format)
 
   if (all(dims != 0)) {
     data <- array(data = value, dim = dims)
@@ -534,53 +549,16 @@ write_zarr_string_scalar <- function(
   value <- array(data = value, dim = 1)
   Rarr::create_empty_zarr_array(
     zarr_array_path = file.path(store, name),
+    # placeholder type, rewritten to a string type just below
     data_type = "|O",
     dim = 1,
     chunk_dim = 1,
     compressor = .get_compressor(compression),
     zarr_version = zarr_format
   )
-  # Rarr doesn't yet provide an explicit interface to deal with VLen-UTF8 so
-  # we patch the metadata by hand.
-  # Will be resolved by https://github.com/Huber-group-EMBL/Rarr/issues/111.
-  if (zarr_format == 2L) {
-    zarr_json_path <- file.path(store, name, ".zarray")
-    zarr_json <- jsonlite::read_json(zarr_json_path)
-    zarr_json$filters <- c(
-      zarr_json$filters,
-      list(list(id = "vlen-utf8"))
-    )
-    jsonlite::write_json(
-      zarr_json,
-      zarr_json_path,
-      auto_unbox = TRUE,
-      pretty = TRUE,
-      null = "null"
-    )
-  }
-  if (zarr_format == 3L) {
-    zarr_json_path <- file.path(store, name, "zarr.json")
-    zarr_json <- jsonlite::read_json(zarr_json_path)
-    zarr_json$data_type <- "string"
-    # There should be only one bytes-array codec
-    zarr_json$codecs <- lapply(
-      zarr_json$codecs,
-      function(codec) {
-        if (codec$name == "bytes") {
-          list(name = "vlen-utf8")
-        } else {
-          codec
-        }
-      }
-    )
-    jsonlite::write_json(
-      zarr_json,
-      zarr_json_path,
-      auto_unbox = TRUE,
-      pretty = TRUE,
-      null = "null"
-    )
-  }
+  # TODO: Remove this call, and write the scalar as a string directly, once
+  # https://github.com/Huber-group-EMBL/Rarr/issues/111 is resolved
+  patch_zarr_vlen_utf8(store, name, zarr_format)
   Rarr::update_zarr_array(
     value,
     zarr_array_path = file.path(store, name),


### PR DESCRIPTION
**Related to:** #455

`write_zarr_string_array()` and `write_zarr_string_scalar()` each carry the same 46 lines of vlen-utf8 JSON patching. Move it to `patch_zarr_vlen_utf8()` so the v2 filter and the v3 codec only have to be kept in step in one place.

It is also now spelled out -- at the helper and at both call sites -- that this is a temporary workaround for Rarr not being able to write VLen-UTF8 itself, so it is obvious what to delete once https://github.com/Huber-group-EMBL/Rarr/issues/111 lands. That includes the `data_type = "|O"` placeholders, which only exist to be rewritten afterwards.

No behaviour change -- I diffed the stores written before and after and they are identical.
